### PR TITLE
Disabled the Content Security Policy so reports are displayed correctly on newer versions of Jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <!-- which version of Jenkins is this plugin built against? -->
-    <version>1.466</version>
+    <version>2.3</version>
     <relativePath />
   </parent>
 
@@ -13,6 +13,17 @@
   <name>Thucydides Jenkins Plugin</name>
   <version>0.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
+
+  <properties>
+    <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
+    <jenkins.version>1.651.2</jenkins.version>
+    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
+    <java.level>7</java.level>
+    <!-- Jenkins Test Harness version you use to test the plugin. -->
+    <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
+    <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
   <scm>
     <connection>scm:git:ssh://github.com/jenkinsci/thucydides-plugin.git</connection>
@@ -28,11 +39,12 @@
       <name>Harald Wellmann</name>
       <email>harald.wellmann@gmx.de</email>
     </developer>
+    <developer>
+      <id>hazmeister</id>
+      <name>Harry King</name>
+      <url>https://github.com/hazmeister</url>
+    </developer>
   </developers>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
 
   <build>
     <plugins>
@@ -41,8 +53,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       

--- a/src/main/java/net/thucydides/jenkins/ThucydidesBuildAction.java
+++ b/src/main/java/net/thucydides/jenkins/ThucydidesBuildAction.java
@@ -23,19 +23,18 @@
  */
 package net.thucydides.jenkins;
 
-import static net.thucydides.jenkins.ThucydidesPlugin.getBuildReportFolder;
 import hudson.FilePath;
-import hudson.model.Action;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
 import hudson.model.DirectoryBrowserSupport;
-
-import java.io.IOException;
-
-import javax.servlet.ServletException;
-
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+import static net.thucydides.jenkins.ThucydidesPlugin.getBuildReportFolder;
 
 /**
  * Build level action to display the Thucydides result summary of the last build.
@@ -92,10 +91,14 @@ public class ThucydidesBuildAction implements Action {
      */
     public DirectoryBrowserSupport doDynamic(StaplerRequest req, StaplerResponse rsp)
             throws IOException, ServletException, InterruptedException {
+        // since Jenkins blocks JavaScript as described at
+        // https://wiki.jenkins-ci.org/display/JENKINS/Configuring+Content+Security+Policy and fact that plugin uses JS
+        // to display charts, following must be applied
+        System.setProperty("hudson.model.DirectoryBrowserSupport.CSP", "");
 
         AbstractProject<?, ?> project = build.getProject();
         String title = project.getDisplayName() + " Thucydides Result Summary";
         FilePath systemDirectory = new FilePath(getBuildReportFolder(build));
-        return new DirectoryBrowserSupport(this, systemDirectory, title, null, false);
+        return new DirectoryBrowserSupport(this, systemDirectory, title, getIconFileName(), false);
     }
 }

--- a/src/main/java/net/thucydides/jenkins/ThucydidesPlugin.java
+++ b/src/main/java/net/thucydides/jenkins/ThucydidesPlugin.java
@@ -26,7 +26,7 @@ package net.thucydides.jenkins;
 import hudson.Plugin;
 import hudson.PluginWrapper;
 import hudson.model.AbstractBuild;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 
 import java.io.File;
 
@@ -52,8 +52,7 @@ public class ThucydidesPlugin extends Plugin {
      */
     public static File getBuildReportFolder(AbstractBuild<?, ?> build) {
         assert build != null;
-        File reportFolder = new File(build.getRootDir(), REPORT_FOLDER);
-        return reportFolder;
+        return new File(build.getRootDir(), REPORT_FOLDER);
     }
 
     /**
@@ -62,7 +61,7 @@ public class ThucydidesPlugin extends Plugin {
      * @return resource path
      */
     public static String getPluginResourcePath() {
-        PluginWrapper wrapper = Hudson.getInstance().getPluginManager()
+        PluginWrapper wrapper = Jenkins.getInstance().getPluginManager()
                 .getPlugin(ThucydidesPlugin.class);
         return "/plugin/" + wrapper.getShortName() + "/";
     }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
 The MIT License
 

--- a/src/main/resources/net/thucydides/jenkins/ThucydidesArchiver/config.jelly
+++ b/src/main/resources/net/thucydides/jenkins/ThucydidesArchiver/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
 The MIT License
 


### PR DESCRIPTION
First plugin contribution to Jenkins, so feedback welcome.
- Disabled the Content Security Policy so reports are displayed correctly on Jenkins 1.641 / Jenkins 1.625.3 and newer
- Updated pom file so tests could be run against newer versions of Jenkins
- Send icon with requests (fixes missing favicon on Vivaldi browser)
